### PR TITLE
(#26) Ensure publish automatically on origin/main branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+      with:
+        fetch-depth: 2  # Ensure that we get previous commit to compare version with
     - uses: actions/setup-python@v3
       with:
         python-version: "3.10.x"

--- a/publish.sh
+++ b/publish.sh
@@ -9,6 +9,8 @@ else
     new_version=$(git diff HEAD~1 -- pyproject.toml | grep '^\+version' | tr -dc '0-9.')
 fi
 
+echo "On branch \"$_current_git_branch\": old_version=\"$old_version\", new_version=\"$new_version\""
+
 if [ -z "$new_version" ]
 then
     echo "Changes not meant as a new version. Aborting."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "typer >= 0.4.0, < 0.5.0",
 ]
 name = "aiotaskq"
-version = "0.0.7"
+version = "0.0.8"
 readme = "README.md"
 description = "A simple asynchronous task queue"
 authors = [


### PR DESCRIPTION
We make sure that we're able to get previous commit (HEAD~1) on Github Action so that we can compare the version from it with that from the current commit (HEAD). This should trigger the steps where we build the package and publish it.