### PR TITLE
(#26) Fix not auto-publishing on origin/main

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,5 +1,5 @@
-current_git_branch=$(git branch | grep -e '^*\s.*' | cut -d" " -f2 | tr -d "\n")
-is_main_branch=$(echo $current_git_branch | tr -d "\n" | grep -E "^(origin\/)?main$")
+current_git_branch=$(git name-rev --name-only HEAD)
+is_main_branch=$(echo $current_git_branch | tr -d "\n" | grep -E "^main$")
 if [[ -z "$is_main_branch" ]]
 then
     old_version=$(git diff origin/main -- pyproject.toml | grep '^\-version' | tr -dc '0-9.')
@@ -9,7 +9,7 @@ else
     new_version=$(git diff HEAD~1 -- pyproject.toml | grep '^\+version' | tr -dc '0-9.')
 fi
 
-echo "On branch \"$_current_git_branch\": old_version=\"$old_version\", new_version=\"$new_version\""
+echo "On branch \"$current_git_branch\": old_version=\"$old_version\", new_version=\"$new_version\""
 
 if [ -z "$new_version" ]
 then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "typer >= 0.4.0, < 0.5.0",
 ]
 name = "aiotaskq"
-version = "0.0.8"
+version = "0.0.9"
 readme = "README.md"
 description = "A simple asynchronous task queue"
 authors = [


### PR DESCRIPTION
Previously we get the name of the current branch
by using `git branch ...` but it did not give
an easily parse-able result, and we got the parsing wrong. Because we got the wrong branch name,
we got the wrong version diff, and hence not trigger publishing to pypi.

Now, we use a more cleaner command: `git name-rev
--name-only HEAD` and we should be getting the
correct version diff and hence trigger publishing
to pypi correctly.