### PR TITLE
(#52) Ensure rate-limit tasks if worker-rate-limit option is provided

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -254,7 +254,7 @@ exclude-too-few-public-methods=
 ignored-parents=
 
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=10
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7

--- a/.pylintrc.tests
+++ b/.pylintrc.tests
@@ -257,7 +257,7 @@ exclude-too-few-public-methods=
 ignored-parents=
 
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=10
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7

--- a/src/aiotaskq/__main__.py
+++ b/src/aiotaskq/__main__.py
@@ -29,15 +29,17 @@ def aiotaskq(version: bool = typer.Option(None, "--version", callback=_version_c
 @cli.command(name="worker")
 def worker_command(
     app: str,
-    concurrency: t.Optional[int] = Defaults.concurrency,
-    poll_interval_s: t.Optional[float] = Defaults.poll_interval_s,
-    concurrency_type: t.Optional[ConcurrencyType] = Defaults.concurrency_type,
+    concurrency: t.Optional[int] = Defaults.concurrency(),
+    poll_interval_s: t.Optional[float] = Defaults.poll_interval_s(),
+    concurrency_type: t.Optional[ConcurrencyType] = Defaults.concurrency_type(),
+    worker_rate_limit: t.Optional[int] = Defaults.worker_rate_limit(),
 ):
     """Command to start workers."""
     run_worker_forever(
         app_import_path=app,
         concurrency=concurrency,
         concurrency_type=concurrency_type,
+        worker_rate_limit=worker_rate_limit,
         poll_interval_s=poll_interval_s,
     )
 

--- a/src/aiotaskq/interfaces.py
+++ b/src/aiotaskq/interfaces.py
@@ -93,6 +93,7 @@ class IPubSub(t.Protocol):
             print(f"Got message: {message}")
     ```
     """
+
     def __init__(self, url: str, poll_interval_s: float, *args, **kwargs):
         """Initialize the pubsub class."""
 

--- a/src/aiotaskq/task.py
+++ b/src/aiotaskq/task.py
@@ -74,17 +74,17 @@ class Task(t.Generic[P, RT]):
     """
 
     __qualname__: str
+    func: t.Callable[P, RT]
 
     def __init__(self, func: t.Callable[P, RT]) -> None:
         """
         Store the underlying function and an automatically generated task_id in the Task instance.
         """
-        self._f = func
-        self._id = uuid.uuid4()
+        self.func = func
 
     def __call__(self, *args, **kwargs) -> RT:
         """Call the task synchronously, by directly executing the underlying function."""
-        return self._f(*args, **kwargs)
+        return self.func(*args, **kwargs)
 
     def generate_task_id(self) -> str:
         """Generate a unique id for an individual call to a task."""

--- a/src/tests/apps/simple_app.py
+++ b/src/tests/apps/simple_app.py
@@ -45,14 +45,7 @@ if __name__ == "__main__":  # pragma: no cover
     from asyncio import get_event_loop
 
     async def main():
-        # ret = await join.apply_async(["Hello", "World"], delimiter=" ")
-        ret = await asyncio.gather(
-            *[
-                wait.apply_async(1),
-                wait.apply_async(1),
-                wait.apply_async(1),
-            ],
-        )
+        ret = await join.apply_async(["Hello", "World"], delimiter=" ")
         print(ret)
 
     loop = get_event_loop()

--- a/src/tests/apps/simple_app.py
+++ b/src/tests/apps/simple_app.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import aiotaskq
 
 
@@ -7,13 +9,20 @@ def echo(x):
 
 
 @aiotaskq.task
+async def wait(t_s: int) -> int:
+    """Wait asynchronously for `t_s` seconds."""
+    await asyncio.sleep(t_s)
+    return t_s
+
+
+@aiotaskq.task
 def add(x: int, y: int) -> int:
     return x + y
 
 
 @aiotaskq.task
 def power(a: int, b: int = 1) -> int:
-    return a ** b
+    return a**b
 
 
 @aiotaskq.task
@@ -36,7 +45,14 @@ if __name__ == "__main__":  # pragma: no cover
     from asyncio import get_event_loop
 
     async def main():
-        ret = await join.apply_async(["Hello", "World"], delimiter=" ")
+        # ret = await join.apply_async(["Hello", "World"], delimiter=" ")
+        ret = await asyncio.gather(
+            *[
+                wait.apply_async(1),
+                wait.apply_async(1),
+                wait.apply_async(1),
+            ],
+        )
         print(ret)
 
     loop = get_event_loop()

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -16,15 +16,17 @@ class WorkerFixture:
     async def start(
         self,
         app: str,
-        concurrency: t.Optional[int] = Defaults.concurrency,
-        concurrency_type: t.Optional[ConcurrencyType] = Defaults.concurrency_type,
-        poll_interval_s: t.Optional[float] = Defaults.poll_interval_s,
+        concurrency: t.Optional[int] = Defaults.concurrency(),
+        concurrency_type: t.Optional[ConcurrencyType] = Defaults.concurrency_type(),
+        worker_rate_limit: int = Defaults.worker_rate_limit(),
+        poll_interval_s: t.Optional[float] = Defaults.poll_interval_s(),
     ) -> None:
         proc = multiprocessing.Process(
             target=lambda: run_worker_forever(
                 app_import_path=app,
                 concurrency=concurrency,
                 concurrency_type=concurrency_type,
+                worker_rate_limit=worker_rate_limit,
                 poll_interval_s=poll_interval_s,
             )
         )
@@ -54,7 +56,8 @@ class WorkerFixture:
 
     def close(self) -> None:
         """Release all resources belonging to the worker process."""
-        self.proc.close()
+        if not self.proc.is_alive():
+            self.proc.close()
 
 
 @pytest.fixture

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -74,6 +74,7 @@ def test_worker_show_proper_help_message():
             "  --poll-interval-s FLOAT         [default: 0.01]\n"
             "  --concurrency-type [multiprocessing]\n"
             "                                  [default: multiprocessing]\n"
+            "  --worker-rate-limit INTEGER     [default: -1]\n"
             "  --help                          Show this message and exit.\n"
         )
         assert output == output_expected

--- a/src/tests/test_concurrency.py
+++ b/src/tests/test_concurrency.py
@@ -1,5 +1,6 @@
 import asyncio
 import typing as t
+from time import time
 
 import pytest
 
@@ -7,6 +8,44 @@ from tests.apps import simple_app
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from tests.conftest import WorkerFixture
+
+
+@pytest.mark.asyncio
+async def test_async_concurrency(worker: "WorkerFixture"):
+    # Given that the worker cli is run with "--concurrency 1" option
+    await worker.start(app=simple_app.__name__, concurrency=1)
+
+    # When multiple async tasks are being queued at the same time
+    t_0 = time()
+    results_actual = await asyncio.gather(*[simple_app.wait.apply_async(t_s=1) for _ in range(5)])
+    t_1 = time()
+
+    # Then those async tasks should run concurrently in that one worker
+    dt_actual = t_1 - t_0
+    error = 0.1
+    assert 1.0 < dt_actual < 1.0 + error
+    # And the results should be correct
+    results_expected = [1, 1, 1, 1, 1]
+    assert results_actual == results_expected
+
+
+@pytest.mark.asyncio
+async def test_async_worker_rate_limit(worker: "WorkerFixture"):
+    # Given that the worker cli is run with "--concurrency 1" and "--worker-rate-limit 3" options
+    await worker.start(app=simple_app.__name__, concurrency=1, worker_rate_limit=3)
+
+    # When multiple async tasks are being queued at the same time
+    t_0 = time()
+    results_actual = await asyncio.gather(*[simple_app.wait.apply_async(t_s=1) for _ in range(5)])
+    t_1 = time()
+
+    # Then those async tasks should run concurrently in that one worker, limited to 3 tasks at a time
+    dt_actual = t_1 - t_0
+    num_batches = 2  # 3 tasks run simultaneously, then 2 tasks run simultaneously
+    assert 1.0 * num_batches < dt_actual < 1.0 * num_batches + 0.2
+    # And the results should be correct
+    results_expected = [1, 1, 1, 1, 1]
+    assert results_actual == results_expected
 
 
 @pytest.mark.asyncio
@@ -41,4 +80,23 @@ async def test_concurrent_async_tasks_return_correctly(worker: "WorkerFixture"):
 
     # Then the results should be correct
     results_expected = [1, 2, 3]
+    assert results_actual == results_expected
+
+
+@pytest.mark.asyncio
+async def test_async__concurrency_and_worker_rate_limit_of_1__effectively_serial(worker: "WorkerFixture"):
+    """Assert that if concurrency=1 & worker-rate-limit=1, tasks will effectively run serially."""
+    # Given that the worker cli is run with "--concurrency 1" and "--worker-rate-limit 1" options
+    await worker.start(app=simple_app.__name__, concurrency=1, worker_rate_limit=1)
+
+    # When multiple async tasks are being queued at the same time
+    t_0 = time()
+    results_actual = await asyncio.gather(*[simple_app.wait.apply_async(t_s=1) for _ in range(5)])
+    t_1 = time()
+
+    # Then those async tasks will run serially
+    dt_actual = t_1 - t_0
+    assert 1.0 * 5 <= dt_actual < 1.1 * 5
+    # And the results should be correct
+    results_expected = [1, 1, 1, 1, 1]
     assert results_actual == results_expected


### PR DESCRIPTION
We rate-limit by using semaphore with value=worker_rate_limit. Rate limit tasks only when asked, so if worker-rate-limit is not provided, we don't use semaphore so any number of tasks can be let in.

Fixes issue #52