### PR TITLE
(#28) Ensure sigterm is handled by coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,4 @@
 source = src/
 parallel = True
 concurrency = multiprocessing
+sigterm = True

--- a/src/aiotaskq/worker.py
+++ b/src/aiotaskq/worker.py
@@ -19,7 +19,7 @@ from .constants import REDIS_URL, RESULTS_CHANNEL_TEMPLATE, TASKS_CHANNEL
 from .interfaces import ConcurrencyType, IConcurrencyManager, IPubSub
 from .pubsub import PubSub
 
-if t.TYPE_CHECKING:
+if t.TYPE_CHECKING:  # pragma: no cover
     from .task import Task
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
This way, coverage can collect data before process termination

Issue was coverage does not handle sigterm by default, so it couldn't get to collect data upon termination: https://github.com/nedbat/coveragepy/issues/1307#issuecomment-1019385403

Need to explicitly tell coverage to handle sigterm: https://coverage.readthedocs.io/en/latest/changes.html#version-6-4-2022-05-22