### PR TITLE
(#64) Support tasks retry & propagate raised exception

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,9 @@ source = src/
 parallel = True
 concurrency = multiprocessing
 sigterm = True
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if TYPE_CHECKING:
+    if t.TYPE_CHECKING:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - run: docker-compose -f ./docker-compose.yml up --detach redis
+    - run: docker compose -f ./docker-compose.yml up --detach redis
     - uses: actions/setup-python@v3
       with:
         python-version: "3.10.x"

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - run: docker-compose -f ./docker-compose.yml up --detach redis
+    - run: docker compose -f ./docker-compose.yml up --detach redis
     - uses: actions/setup-python@v3
       with:
         python-version: "3.10.x"

--- a/.pylintrc
+++ b/.pylintrc
@@ -257,16 +257,16 @@ ignored-parents=
 max-args=10
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=10
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5
 
 # Maximum number of branch for function / method body.
-max-branches=12
+max-branches=15
 
 # Maximum number of locals for function / method body.
-max-locals=15
+max-locals=20
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7
@@ -458,7 +458,11 @@ good-names=i,
            a,
            b,
            c,
-           n
+           n,
+           id,
+           e,
+           s,
+           on
 
 # Good variable names regexes, separated by a comma. If names match any regex,
 # they will always be accepted

--- a/.pylintrc.tests
+++ b/.pylintrc.tests
@@ -461,8 +461,12 @@ good-names=i,
            a,
            b,
            c,
+           e,
            n,
-           ls
+           t,
+           ls,
+           fo,
+           fi
 
 # Good variable names regexes, separated by a comma. If names match any regex,
 # they will always be accepted

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,16 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Python: Attach",
+            "type": "python",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "justMyCode": false
+        },
+        {
             "name": "Main",
             "type": "python",
             "request": "launch",
@@ -31,7 +41,8 @@
                 "-s",
             ],
             "request": "launch",
-            "console": "integratedTerminal"
+            "console": "integratedTerminal",
+            "justMyCode": false
         },
         {
             "name": "Sample Worker (Simple App)",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import asyncio
 import aiotaskq
 
 
-@aiotaskq.task
+@aiotaskq.task()
 def some_task(b: int) -> int:
     # Some task with high cpu usage
     def _naive_fib(n: int) -> int:
@@ -132,22 +132,22 @@ import asyncio
 from aiotaskq import task
 
 
-@task
+@task()
 def task_1(*args, **kwargs):
         pass
 
 
-@task
+@task()
 def task_2(*args, **kwargs):
         pass
 
 
-@task
+@task()
 def task_3(*args, **kwargs):
         pass
 
 
-@task
+@task()
 def task_4(*args, **kwargs):
         pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,12 @@ build-backend = "setuptools.build_meta"
 requires-python = ">=3.9"
 dependencies = [
     "aioredis >= 2.0.0, < 2.1.0",
+    "jsonpickle >= 3.0.0, < 3.1.0",
     "tomlkit >= 0.11.0, < 0.12.0",
     "typer >= 0.4.0, < 0.5.0",
 ]
 name = "aiotaskq"
-version = "0.0.12"
+version = "0.0.13"
 readme = "README.md"
 description = "A simple asynchronous task queue"
 authors = [
@@ -28,7 +29,7 @@ license = { file = "LICENSE" }
 
 [project.optional-dependencies]
 dev = [
-    "black >= 22.1.0, < 22.2.0",
+    "black >= 22.2.0, < 23.0.0",
     "coverage >= 6.4.0, < 6.5.0",
     "mypy >= 0.931, < 1.0",
     "mypy-extensions >= 0.4.0, < 0.5.0",

--- a/src/aiotaskq/__init__.py
+++ b/src/aiotaskq/__init__.py
@@ -7,7 +7,7 @@ Usage::
     import aiotaskq
 
 
-    @aiotaskq.task
+    @aiotaskq.task()
     def some_task(b: int) -> int:
         # Some task with high cpu usage
         def _naive_fib(n: int) -> int:

--- a/src/aiotaskq/__main__.py
+++ b/src/aiotaskq/__main__.py
@@ -2,15 +2,18 @@
 
 #!/usr/bin/env python
 
+import logging
 import typing as t
 
 import typer
 
+from . import __version__
+from .config import Config
 from .interfaces import ConcurrencyType
 from .worker import Defaults, run_worker_forever
-from . import __version__
 
 cli = typer.Typer()
+logging.basicConfig(level=Config.log_level())
 
 
 def _version_callback(value: bool):

--- a/src/aiotaskq/config.py
+++ b/src/aiotaskq/config.py
@@ -1,0 +1,47 @@
+"""
+Module to define and store all configuration values used across the library.
+
+The public object from this module is `Config`. This object wraps
+all the configuration values, which include:
+- Variables
+- Environment variables
+"""
+
+import logging
+from os import environ
+
+from .interfaces import SerializationType
+
+_REDIS_URL = "redis://127.0.0.1:6379"
+
+
+class Config:
+    """
+    Provide configuration values.
+
+    These include:
+    - Variables
+    - Environment variables
+    """
+
+    @staticmethod
+    def serialization_type() -> SerializationType:
+        """Return the serialization type as provided via env var AIOTASKQ_SERIALIZATION."""
+        s: str = environ.get("AIOTASKQ_SERIALIZATION", SerializationType.DEFAULT.value)
+        return SerializationType[s.upper()]
+
+    @staticmethod
+    def log_level() -> int:
+        """Return the log level as provided via env var LOG_LEVEL."""
+        level: int = int(environ.get("AIOTASKQ_LOG_LEVEL", logging.DEBUG))
+        return level
+
+    @staticmethod
+    def broker_url() -> str:
+        """
+        Return the broker url as provided via env var BROKER_URL.
+
+        Defaults to "redis://127.0.0.1:6379".
+        """
+        broker_url: str = environ.get("BROKER_URL", _REDIS_URL)
+        return broker_url

--- a/src/aiotaskq/constants.py
+++ b/src/aiotaskq/constants.py
@@ -1,5 +1,30 @@
-"""Module to define and store all constants used across the library."""
+"""
+Module to define and store all constants used across the library.
 
-REDIS_URL = "redis://127.0.0.1:6379"
-TASKS_CHANNEL = "channel:tasks"
-RESULTS_CHANNEL_TEMPLATE = "channel:results:{task_id}"
+The public object from this module is `Constants`. This object wraps
+all the constants, which include:
+- Static methods that return constant values
+"""
+
+
+_TASKS_CHANNEL = "channel:tasks"
+_RESULTS_CHANNEL_TEMPLATE = "channel:results:{task_id}"
+
+
+class Constants:
+    """
+    Provide all the constants.
+
+    These include:
+    - Static methods that return constant values
+    """
+
+    @staticmethod
+    def tasks_channel() -> str:
+        """Return the channel name used for transporting task requests on the broker."""
+        return _TASKS_CHANNEL
+
+    @staticmethod
+    def results_channel_template() -> str:
+        """Return the template chnnale name used for transporting task results on the broker."""
+        return _RESULTS_CHANNEL_TEMPLATE

--- a/src/aiotaskq/exceptions.py
+++ b/src/aiotaskq/exceptions.py
@@ -19,3 +19,7 @@ class ConcurrencyTypeNotSupported(Exception):
 
 class InvalidArgument(Exception):
     """A task is applied with invalid arguments."""
+
+
+class InvalidRetryOptions(Exception):
+    """A task is defined with invalid retry options."""

--- a/src/aiotaskq/interfaces.py
+++ b/src/aiotaskq/interfaces.py
@@ -137,3 +137,61 @@ class IWorkerManager(IWorker):
     """
 
     concurrency_manager: IConcurrencyManager
+
+
+class SerializationType(str, enum.Enum):
+    """Specify the types of serialization supported."""
+
+    JSON = "json"
+    DEFAULT = JSON
+
+
+T = t.TypeVar("T")
+
+
+class ISerialization(t.Protocol, t.Generic[T]):
+    """Define the interface required to serialize and deserialize a generic object."""
+
+    @classmethod
+    def serialize(cls, obj: T) -> bytes:
+        """Serialize any object into bytes."""
+
+    @classmethod
+    def deserialize(cls, klass: type[T], s: bytes) -> T:
+        """Deserialize bytes into any object."""
+
+
+class RetryOptions(t.TypedDict):
+    """
+    Specify the available retry options.
+
+    max_retries int | None: The number times to keep retrying the execution of the task
+                            until the task executes successfully. Counting starts from
+                            0 so if max_retries = 2 for example, then the task will execute
+                            1 + 2 times (1 time for first execution, 2 times for re-try) in the
+                            worst case scenario.
+    on tuple[type[Exception], ...]: The tuple of exception classes to retry on. The task will
+                                    will only be retried if that exception that is raised
+                                    during task execution is an instance of one of the listed
+                                    exception classes.
+
+                                    Examples:
+
+                                        If `on=(Exception,)` then any kind of exception will trigger
+                                        a retry.
+
+                                        If `on=(ExceptionA, ExceptionB,)` and during task
+                                        execution ExceptionC was raised, then retry is not triggered.
+
+                                        If `on=tuple()` then during task definition aiotaskq will raise
+                                        `InvalidRetryOptions`
+    """
+
+    max_retries: int | None
+    on: tuple[type[Exception], ...]
+
+
+class TaskOptions(t.TypedDict):
+    """Specify the options available for a task."""
+
+    retry: RetryOptions | None

--- a/src/aiotaskq/serde.py
+++ b/src/aiotaskq/serde.py
@@ -1,0 +1,160 @@
+"""
+Define serialization and deserialization utilities.
+"""
+
+import importlib
+import json
+import types
+import typing as t
+
+import jsonpickle
+
+from .config import Config
+from .interfaces import ISerialization, SerializationType, T
+from .task import AsyncResult, Task
+
+
+class Serialization(t.Generic[T]):
+    """Expose the JSON serialization and deserialization logic for any object behined a simple abstraction."""
+
+    @classmethod
+    def serialize(cls, obj: "T") -> bytes:
+        """Serialize an object of type T into bytes via an appropriate serialization logic."""
+        s_klass = _get_serde_class(obj.__class__)
+        return s_klass.serialize(obj)
+
+    @classmethod
+    def deserialize(cls, klass: type["T"], s: bytes) -> "T":
+        """Deserialize bytes into an object of type T via an appropriate deserialization logic."""
+        s_klass = _get_serde_class(klass)
+        return s_klass.deserialize(klass, s)
+
+
+def _get_serde_class(klass: type["T"]) -> type[ISerialization["T"]]:
+    """Get the Serializer-Deserializer class that implements `serialize` and `deserialize`."""
+    map_ = {
+        (Task, SerializationType.JSON): JsonTaskSerialization,
+        (AsyncResult, SerializationType.JSON): JsonAsyncResultSerialization,
+    }
+    if (klass, Config.serialization_type()) not in map_:
+        assert False, "Should not reach here"  # pragma: no cover
+    return map_[klass, Config.serialization_type()]
+
+
+class JsonTaskSerialization(Serialization):
+    """Define the JSON serialization and deserialization logic for Task."""
+
+    class TaskOptionsRetryOnDict(t.TypedDict):
+        """Define the JSON structure of the retry options of a serialized Task object."""
+
+        max_retries: int | None
+        on: str
+
+    class TaskOptionsDict(t.TypedDict):
+        """Define the JSON structure of the options of a serialized Task object."""
+
+        retry: "JsonTaskSerialization.TaskOptionsRetryOnDict | None"
+
+    class TaskDict(t.TypedDict):
+        """Define the JSON structure of a serialized Task object."""
+
+        func: str
+        task_id: str
+        args: tuple[t.Any, ...]
+        kwargs: dict
+        options: "JsonTaskSerialization.TaskOptionsDict"
+
+    @classmethod
+    def serialize(cls, obj: "Task") -> bytes:
+        """Serialize a Task object to JSON bytes."""
+        options: JsonTaskSerialization.TaskOptionsDict = {}
+        retry: JsonTaskSerialization.TaskOptionsRetryOnDict | None = None
+        if obj.retry is not None:
+            retry = {
+                "max_retries": obj.retry["max_retries"],
+                "on": jsonpickle.encode(obj.retry["on"]),
+            }
+            options["retry"] = retry
+        d_obj: JsonTaskSerialization.TaskDict = {
+            "func": {
+                "module": obj.__module__,
+                "qualname": obj.__qualname__,
+            },
+            "task_id": obj.id,
+            "args": obj.args,
+            "kwargs": obj.kwargs,
+            "options": options,
+        }
+        s = f"json|{json.dumps(d_obj)}"
+        return s.encode("utf-8")
+
+    @classmethod
+    def deserialize(cls, klass: type["Task"], s: bytes) -> "Task":
+        """Deserialize JSON bytes to a Task object."""
+        s_type, s_obj = s.decode("utf-8").split("|", 1)
+        assert s_type == "json"
+        d_obj: JsonTaskSerialization.TaskDict = json.loads(s_obj)
+
+        d_options: JsonTaskSerialization.TaskOptionsDict = d_obj["options"]
+        retry: JsonTaskSerialization.TaskOptionsRetryOnDict | None = None
+        if d_options.get("retry") is not None:
+            s_retry: "JsonTaskSerialization.TaskOptionsRetryOnDict" = d_obj["options"]["retry"]
+            max_retries: int | None = s_retry["max_retries"]
+            retry_on: tuple[type[Exception], ...] = jsonpickle.decode(s_retry["on"])
+            retry = {
+                "max_retries": max_retries,
+                "on": retry_on,
+            }
+
+        func_module_path, func_qualname = d_obj["func"]["module"], d_obj["func"]["qualname"]
+        func_module: types.ModuleType = importlib.import_module(func_module_path)
+        func: types.FunctionType = getattr(func_module, func_qualname).func
+        assert func is not None
+
+        obj: "Task" = klass(
+            func=func,
+            task_id=d_obj["task_id"],
+            args=d_obj["args"],
+            kwargs=d_obj["kwargs"],
+            retry=retry,
+        )
+        return obj
+
+
+class JsonAsyncResultSerialization(Serialization):
+    """Define the JSON serialization and deserialization logic for AsyncResult."""
+
+    class AsyncResultDict(t.TypedDict):
+        """Define the JSON structure of a serialized AsyncResult."""
+
+        task_id: str
+        ready: bool
+        result: t.Any
+        error: str
+
+    @classmethod
+    def serialize(cls, obj: "AsyncResult") -> bytes:
+        """Serialize AsyncResult object to JSON bytes."""
+        error_s: str = jsonpickle.encode(obj.error)
+        result_json: JsonAsyncResultSerialization.AsyncResultDict = {
+            "task_id": obj.task_id,
+            "ready": obj.ready,
+            "result": obj.result,
+            "error": error_s,
+        }
+        return f"json|{json.dumps(result_json)}".encode("utf-8")
+
+    @classmethod
+    def deserialize(cls, klass: type["AsyncResult"], s: bytes) -> "AsyncResult":
+        """Deserialize JSON bytes to a AsyncResult object."""
+        s: str = s.decode("utf-8")
+        s_type, s_obj = s.split("|", 1)
+        assert s_type == "json"
+        obj_d: JsonAsyncResultSerialization.AsyncResultDict = json.loads(s_obj)
+        result: "AsyncResult" = klass(
+            task_id=obj_d["task_id"],
+            ready=obj_d["ready"],
+            result=obj_d["result"],
+            error=jsonpickle.decode(obj_d["error"]),
+        )
+        return result

--- a/src/tests/apps/simple_app.py
+++ b/src/tests/apps/simple_app.py
@@ -1,36 +1,122 @@
 import asyncio
+import logging
+import os
 
 import aiotaskq
 
+logger = logging.getLogger(__name__)
 
-@aiotaskq.task
+
+class SomeException(Exception):
+    pass
+
+
+class SomeException2(Exception):
+    pass
+
+
+@aiotaskq.task(
+    options={
+        "retry": {
+            "max_retries": 2,
+            "on": (SomeException,),
+        },
+    },
+)
+async def append_to_file(filename: str) -> None:
+    """
+    Append pid to file for testing purpose and unconditionally raise SomeException.
+
+    How is this useful for testing?
+
+    This task is defined with retry options. By appending to a file and raising exception at the
+    end, we can check how many times this task has been applied and verify if the retry logic is
+    working.
+    """
+    _append_pid_to_file(filename=filename)
+    raise SomeException("Some error")
+
+
+@aiotaskq.task()
+async def append_to_file_2(filename: str) -> None:
+    """
+    Append pid to file for testing purpose and unconditionally raise SomeException2.
+
+    This works exactly the same as `append_to_file` except that:
+     1. We're raising a different exception.
+     2. The task is not defined with the retry options
+
+    This can help us verify that:
+     1. The retry logic can also be provided during task call instead of only during task
+        defintion
+     2. The retry logic is applied only against the specified exception classes
+    """
+    _append_pid_to_file(filename=filename)
+    raise SomeException2
+
+
+@aiotaskq.task(
+    options={
+        "retry": {
+            "max_retries": 2,
+            "on": (SomeException,),
+        },
+    },
+)
+async def append_to_file_first_3_times_with_error(filename: str) -> None:
+    """
+    Append pid to file for testing purpose and *conditionally* raise SomeException.
+
+    This works exactly the same as `append_to_file` except that we're raising
+    SomeException only on a certain condition.
+
+    This can help us verify that a task will only be retried while it fails -- once
+    it successfully run without error, it will no longer be retried.
+    """
+    _append_pid_to_file(filename=filename)
+    # If func has been called <= 2 times (file has <= 2 lines), raise SomeException2.
+    # Else, return without error.
+    with open(filename, mode="r", encoding="utf-8") as fi:
+        num_lines = len(fi.read().rstrip("\n").split("\n"))
+    if num_lines <= 2:
+        raise SomeException
+
+
+def _append_pid_to_file(filename: str) -> None:
+    content: str = str(os.getpid())
+    with open(filename, mode="a", encoding="utf-8") as fo:
+        fo.write(content + "\n")
+        fo.flush()
+
+
+@aiotaskq.task()
 def echo(x):
     return x
 
 
-@aiotaskq.task
+@aiotaskq.task()
 async def wait(t_s: int) -> int:
     """Wait asynchronously for `t_s` seconds."""
     await asyncio.sleep(t_s)
     return t_s
 
 
-@aiotaskq.task
+@aiotaskq.task()
 def add(x: int, y: int) -> int:
     return x + y
 
 
-@aiotaskq.task
+@aiotaskq.task()
 def power(a: int, b: int = 1) -> int:
     return a**b
 
 
-@aiotaskq.task
+@aiotaskq.task()
 def join(ls: list, delimiter: str = ",") -> str:
     return delimiter.join([str(x) for x in ls])
 
 
-@aiotaskq.task
+@aiotaskq.task()
 def some_task(b: int) -> int:
     # Some task with high cpu usage
     def _naive_fib(n: int) -> int:

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -7,6 +7,7 @@ import typing as t
 import pytest
 
 from aiotaskq.interfaces import ConcurrencyType
+from aiotaskq.concurrency_manager import ConcurrencyManagerSingleton
 from aiotaskq.worker import Defaults, run_worker_forever
 
 
@@ -21,6 +22,9 @@ class WorkerFixture:
         worker_rate_limit: int = Defaults.worker_rate_limit(),
         poll_interval_s: t.Optional[float] = Defaults.poll_interval_s(),
     ) -> None:
+        # Reset singleton so each test is isolated
+        ConcurrencyManagerSingleton.reset()
+
         proc = multiprocessing.Process(
             target=lambda: run_worker_forever(
                 app_import_path=app,
@@ -66,3 +70,11 @@ def worker():
     yield worker_
     worker_.terminate()
     worker_.close()
+
+
+@pytest.fixture
+def some_file():
+    filename = "./some_file.txt"
+    yield filename
+    if os.path.exists(filename):
+        os.remove(filename)

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -8,6 +8,7 @@ import typer
 
 from aiotaskq import __version__
 from aiotaskq.__main__ import _version_callback
+from aiotaskq.worker import Defaults
 
 
 def test_root_show_proper_help_message():
@@ -59,6 +60,8 @@ def test_version():
 
 def test_worker_show_proper_help_message():
     bash_command = "aiotaskq worker --help"
+    default_cpu_count: int = multiprocessing.cpu_count()
+    default_poll_interval_s: float = Defaults.poll_interval_s()
     with os.popen(bash_command) as pipe:
         output = pipe.read()
         output_expected = (
@@ -70,8 +73,8 @@ def test_worker_show_proper_help_message():
             "  APP  [required]\n"
             "\n"
             "Options:\n"
-            f"  --concurrency INTEGER           [default: {multiprocessing.cpu_count()}]\n"
-            "  --poll-interval-s FLOAT         [default: 0.01]\n"
+            f"  --concurrency INTEGER           [default: {default_cpu_count}]\n"
+            f"  --poll-interval-s FLOAT         [default: {default_poll_interval_s}]\n"
             "  --concurrency-type [multiprocessing]\n"
             "                                  [default: multiprocessing]\n"
             "  --worker-rate-limit INTEGER     [default: -1]\n"

--- a/src/tests/test_concurrency.py
+++ b/src/tests/test_concurrency.py
@@ -6,7 +6,7 @@ import pytest
 
 from tests.apps import simple_app
 
-if t.TYPE_CHECKING:  # pragma: no cover
+if t.TYPE_CHECKING:
     from tests.conftest import WorkerFixture
 
 
@@ -84,7 +84,9 @@ async def test_concurrent_async_tasks_return_correctly(worker: "WorkerFixture"):
 
 
 @pytest.mark.asyncio
-async def test_async__concurrency_and_worker_rate_limit_of_1__effectively_serial(worker: "WorkerFixture"):
+async def test_async__concurrency_and_worker_rate_limit_of_1__effectively_serial(
+    worker: "WorkerFixture",
+):
     """Assert that if concurrency=1 & worker-rate-limit=1, tasks will effectively run serially."""
     # Given that the worker cli is run with "--concurrency 1" and "--worker-rate-limit 1" options
     await worker.start(app=simple_app.__name__, concurrency=1, worker_rate_limit=1)

--- a/src/tests/test_concurrency_manager.py
+++ b/src/tests/test_concurrency_manager.py
@@ -1,5 +1,6 @@
 from aiotaskq.exceptions import ConcurrencyTypeNotSupported
 from aiotaskq.concurrency_manager import ConcurrencyManagerSingleton
+from aiotaskq.interfaces import ConcurrencyType
 
 
 def test_unsupported_concurrency_type():
@@ -18,3 +19,18 @@ def test_unsupported_concurrency_type():
         assert (
             str(error) == 'Concurrency type "some-incorrect-concurrency-type" is not yet supported.'
         )
+
+
+def test_singleton():
+    # When getting the concurrency_manager instance more than once
+    instance_1 = ConcurrencyManagerSingleton.get(
+        concurrency_type=ConcurrencyType.MULTIPROCESSING,
+        concurrency=4,
+    )
+    instance_2 = ConcurrencyManagerSingleton.get(
+        concurrency_type=ConcurrencyType.MULTIPROCESSING,
+        concurrency=4,
+    )
+
+    # Then the both instances should be the identical instance
+    assert instance_1 is instance_2

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -13,7 +13,7 @@ async def test_sync_and_async_parity__simple_app(worker: WorkerFixture):
     await worker.start(app=app.__name__, concurrency=8)
     # Then there should be parity between sync and async call of the tasks
     tests: list[tuple[Task, tuple, dict]] = [
-        (simple_app.wait, tuple() ,{"t_s": 1}),
+        (simple_app.wait, tuple(), {"t_s": 1}),
         (simple_app.echo, (42,), {}),
         (simple_app.add, tuple(), {"x": 41, "y": 1}),
         (simple_app.power, (2,), {"b": 64}),

--- a/src/tests/test_serde.py
+++ b/src/tests/test_serde.py
@@ -1,0 +1,80 @@
+from importlib import import_module
+import json
+
+from aiotaskq.serde import JsonTaskSerialization
+from aiotaskq.task import Task, task
+
+
+@task()
+def some_task(a: int, b: int) -> int:
+    return a * b
+
+
+class SomeException(Exception):
+    pass
+
+
+@task(
+    options={
+        "retry": {"max_retries": 1, "on": (SomeException,)},
+    },
+)
+def some_task_2(a: int, b: int) -> int:
+    return a * b
+
+
+def test_serialize_task_to_json():
+    # Given a task definition
+    assert isinstance(some_task, Task)
+
+    # When the task has been serialized to json
+    task_serialized = JsonTaskSerialization.serialize(some_task)
+
+    # Then the resulting json should be in correct type and format
+    assert isinstance(task_serialized, bytes)
+    # And should able to deserialized into the same task
+    task_deserialized = JsonTaskSerialization.deserialize(Task, task_serialized)
+    task_format_str, task_serialized_str = task_serialized.decode("utf-8").split("|", 1)
+    assert task_format_str == "json"
+    # And the task should be serialized into correct json
+    task_serialized_dict = json.loads(task_serialized_str)
+    assert task_serialized_dict == {
+        "func": {"module": "tests.test_serde", "qualname": "some_task"},
+        "task_id": None,
+        "args": None,
+        "kwargs": None,
+        "options": {},
+    }
+    # And should be functionally the same as the original task
+    assert task_deserialized.func(1, 2) == some_task.func(1, 2)
+    assert task_deserialized(3, 4) == some_task(3, 4)
+
+
+def test_serialize_task_to_json__with_retry_param():
+    # Given a task definition
+    assert isinstance(some_task_2, Task)
+
+    # When the task has been serialized to json
+    task_serialized = JsonTaskSerialization.serialize(some_task_2)
+
+    # Then the task should be serialized in the correct type and format
+    assert isinstance(task_serialized, bytes)
+    task_format_str, task_serialized_str = task_serialized.decode("utf-8").split("|", 1)
+    assert task_format_str == "json"
+    # And the serialized task should contain information about retry
+    task_serialized_dict = json.loads(task_serialized_str)
+    assert task_serialized_dict == {
+        "func": {"module": "tests.test_serde", "qualname": "some_task_2"},
+        "task_id": None,
+        "args": None,
+        "kwargs": None,
+        "options": {
+            "retry": {
+                "max_retries": 1,
+                "on": '{"py/tuple": [{"py/type": "tests.test_serde.SomeException"}]}',
+            },
+        },
+    }
+    # And the deserialized task should function the same as the original
+    task_deserialized = import_module(task_serialized_dict["func"]["module"]).some_task_2
+    assert task_deserialized(2, 3) == some_task_2(2, 3)

--- a/src/tests/test_task.py
+++ b/src/tests/test_task.py
@@ -1,11 +1,13 @@
+import os
 from typing import TYPE_CHECKING
 
 import pytest
 
-from aiotaskq.exceptions import InvalidArgument
+from aiotaskq.task import task as task_decorator
+from aiotaskq.exceptions import InvalidArgument, InvalidRetryOptions
 from tests.apps import simple_app
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from aiotaskq.task import Task
     from tests.conftest import WorkerFixture
 
@@ -50,6 +52,215 @@ async def test_invalid_argument_provided_to_apply_async(
         error = exc
     finally:
         assert str(error) == (
-            f"These arguments are invalid: args={invalid_args},"
-            f" kwargs={invalid_kwargs}"
+            f"These arguments are invalid: args={invalid_args}," f" kwargs={invalid_kwargs}"
         )
+
+
+@pytest.mark.asyncio
+async def test_retry_as_per_task_definition(worker: "WorkerFixture", some_file: str):
+    # Given a worker running in the background
+    await worker.start(simple_app.__name__, concurrency=1)
+    # And a task defined with retry configuration
+    assert simple_app.append_to_file.retry["max_retries"] == 2
+    assert simple_app.append_to_file.retry["on"] == (simple_app.SomeException,)
+    # And the task will raise an exception when called as a function
+    exception = None
+    try:
+        await simple_app.append_to_file(some_file)
+    except simple_app.SomeException as e:
+        exception = e
+    finally:
+        if os.path.exists(some_file):
+            os.remove(some_file)
+        assert isinstance(exception, simple_app.SomeException)
+
+    # When the task has been applied
+    exception = None
+    try:
+        await simple_app.append_to_file.apply_async(filename=some_file)
+    except simple_app.SomeException as exc:
+        exception = exc
+    finally:
+        # Then the task should be retried as many times as configured
+        with open(some_file, encoding="utf-8") as fi:
+            assert len(fi.readlines()) == 1 + 2, f"file: {fi.readlines()}"  # First call + 2 retries
+        assert isinstance(exception, simple_app.SomeException)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "retry_on,retries_expected",
+    [
+        (
+            (
+                simple_app.SomeException,
+                simple_app.SomeException2,
+            ),
+            1,
+        ),
+        (
+            (
+                simple_app.SomeException,
+                simple_app.SomeException2,
+            ),
+            2,
+        ),
+    ],
+)
+async def test_retry_as_per_task_call(
+    worker: "WorkerFixture",
+    retry_on: tuple[type[Exception], ...],
+    retries_expected: int,
+    some_file: str,
+):
+    # Given a worker running in the background
+    await worker.start(simple_app.__name__, concurrency=1)
+    # And a task defined WITHOUT retry configuration
+    assert simple_app.append_to_file_2.retry is None
+    # And the task will raise an exception when called
+    exception = None
+    try:
+        await simple_app.append_to_file_2.func(some_file)
+    except simple_app.SomeException2 as e:
+        exception = e
+    finally:
+        assert isinstance(exception, simple_app.SomeException2)
+    if os.path.exists(some_file):
+        os.remove(some_file)
+
+    # When the task is applied with retry option
+    exception = None
+    try:
+        await simple_app.append_to_file_2.with_retry(
+            max_retries=retries_expected,
+            on=retry_on,
+        ).apply_async(filename=some_file)
+    except simple_app.SomeException2 as e:
+        exception = e
+    finally:
+        # Then the task should be retried as many times as requested
+        with open(some_file, encoding="utf-8") as fi:
+            assert (
+                len(fi.readlines()) == 1 + retries_expected
+            )  # First call + `retries_expected` retries
+        # And the task should fail with the expected exception
+        assert isinstance(exception, simple_app.SomeException2)
+
+
+@pytest.mark.asyncio
+async def test_no_retry_as_per_task_call(worker: "WorkerFixture", some_file: str):
+    # Given a worker running in the background
+    await worker.start(simple_app.__name__, concurrency=1)
+    # And a task defined WITH retry configuration
+    assert simple_app.append_to_file.retry is not None
+    # And the task will raise an exception when called
+    exception = None
+    try:
+        await simple_app.append_to_file.func(some_file)
+    except simple_app.SomeException as e:
+        exception = e
+    finally:
+        assert isinstance(exception, simple_app.SomeException)
+    if os.path.exists(some_file):
+        os.remove(some_file)
+
+    # When the task is applied with retry option
+    # where retry["on"] doesn't include the exception that the task raises
+    exception = None
+    retry_on_new = (simple_app.SomeException2,)
+    assert [exc not in simple_app.append_to_file.retry["on"] for exc in retry_on_new]
+    try:
+        await simple_app.append_to_file.with_retry(
+            max_retries=2,
+            on=retry_on_new,
+        ).apply_async(filename=some_file)
+    except simple_app.SomeException as e:
+        exception = e
+    finally:
+        # Then the task should NOT be retried
+        with open(some_file, encoding="utf-8") as fi:
+            assert len(fi.readlines()) == 1
+        # And the task should fail with the expected exception
+        assert isinstance(exception, simple_app.SomeException)
+
+
+@pytest.mark.asyncio
+async def test_retry_until_successful(worker: "WorkerFixture", some_file: str):
+    """Assert that task will stop being retried once it's successfully executed without error."""
+    # Given a worker running in the background
+    await worker.start(simple_app.__name__, concurrency=1)
+    # And a task defined WITH retry max_retries = 2
+    assert simple_app.append_to_file_first_3_times_with_error.retry["max_retries"] == 2
+    # And the task will raise an exception when called until it's called for the 3rd time
+    exception = None
+    try:
+        # Call for the first time
+        await simple_app.append_to_file_first_3_times_with_error.func(some_file)
+    except simple_app.SomeException as e:
+        exception = e
+    finally:
+        assert exception is not None
+    exception = None
+    try:
+        # Call for the second time
+        await simple_app.append_to_file_first_3_times_with_error.func(some_file)
+    except simple_app.SomeException as e:
+        exception = e
+    finally:
+        assert exception is not None
+    # Call for the third time (Should no longer raise error)
+    await simple_app.append_to_file_first_3_times_with_error.func(some_file)
+    with open(some_file, mode="r", encoding="utf-8") as fi:
+        num_lines = len(fi.read().rstrip("\n").split("\n"))
+    assert num_lines == 3
+    # Delete the file
+    if os.path.exists(some_file):
+        os.remove(some_file)
+
+    # When the task is applied
+    await simple_app.append_to_file_first_3_times_with_error.apply_async(filename=some_file)
+
+    # Then the task should applied successfully with no error
+    # After having been retried 2 times
+    with open(some_file, mode="r", encoding="utf-8") as fi:
+        num_lines = len(fi.read().rstrip("\n").split("\n"))
+    assert num_lines == 3  # (first call + 2 retries)
+
+
+def test_empty_retry_on_during_task_definition__invalid():
+    # When a task is defined with options.retry.on = tuple()
+    exception = None
+    try:
+        @task_decorator(
+            options={
+                "retry": {
+                    "on": tuple(),
+                    "max_retries": 1,
+                },
+            },
+        )
+        def _():
+            return "Hello world"
+    except Exception as e:  # pylint: disable=broad-except
+        exception = e
+    finally:
+        # Then InvalidRetryOptions should be raised during task definition
+        assert isinstance(exception, InvalidRetryOptions), (
+            "Task definition should fail with InvalidRetryOptions"
+        )
+
+
+@pytest.mark.asyncio
+async def test_empty_retry_on_during_task_call__invalid(some_file: str):
+    # Give a task that is defined without error
+    some_task = simple_app.append_to_file
+
+    exception = None
+    try:
+        # When the task is called with options.retry.on = empty tuple
+        await some_task.with_retry(max_retries=1, on=tuple()).apply_async(some_file)
+    except Exception as e:  # pylint: disable=broad-except
+        exception = e
+    finally:
+        # Then InvalidRetryOptions should be raised during task call
+        assert isinstance(exception, InvalidRetryOptions), "Task call should fail with InvalidRetryOptions"

--- a/src/tests/test_worker.py
+++ b/src/tests/test_worker.py
@@ -8,7 +8,7 @@ import pytest
 from aiotaskq.interfaces import ConcurrencyType
 from aiotaskq.worker import validate_input
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from tests.conftest import WorkerFixture
 
 

--- a/test.sh
+++ b/test.sh
@@ -1,17 +1,16 @@
-pip install --upgrade pip
-pip install -e .[dev]
-
 coverage erase
 
 if [ -z $1 ];
 then
+    pip install --upgrade pip
+    pip install -e .[dev]
     coverage run -m pytest -v
 else
-    coverage run -m pytest -v -k $1
+    coverage run -m pytest --log-level=DEBUG --log-cli-level=DEBUG -s -vvv -k $1
 fi
 
 failed=$?
 
-coverage combine
+coverage combine --quiet
 
 exit $failed


### PR DESCRIPTION
(#64) Support tasks retry & propagate raised exception

For documentation, see:
1. Docstring of `task.task` (which will point to `interfaces.TaskOptions` and in turn `interfaces.RetryOptions`)
2. Tests in `tests.test_task` e.g. `test_retry_as_per_task_definition`
3. Sample usages in `tests.apps.simple_app` e.g. `append_to_file`

Changelist:

* Formalize serialization and deserialization
* Serialize & deserialize exceptions correctly
* Encapsulate retry & retry_on in a new dict 'options'
* Implement serde for AsyncResult
* Ensure generated file deleted after test
* Add jsonpickle to toml file
* Exclude `if TYPE_CHECKING:` from coverage
* Add test for singleton
* Add logging for worker
* Wrap all constants inside `Config` class
* Split the file `constants.py` into `constants.py` and `config.py` (cc @cglotr)
* Refactor `AsyncResult` to be a simple class with no async-await, and remove unused attributes (cc @cglotr)
* Avoid retrying forever (cc @cglotr)
* Handle case with `options.retry.on` is empty